### PR TITLE
Changed Text ui to expect references of std:string instead of a copy

### DIFF
--- a/engine/core/object/ui/Text.cpp
+++ b/engine/core/object/ui/Text.cpp
@@ -79,7 +79,7 @@ unsigned int Text::getMaxTextSize() const{
     return textcomp.maxTextSize;
 }
 
-void Text::setText(std::string text){
+void Text::setText(const std::string &text){
     TextComponent& textcomp = getComponent<TextComponent>();
 
     if (textcomp.text != text){
@@ -94,7 +94,7 @@ std::string Text::getText() const{
     return textcomp.text;
 }
 
-void Text::setFont(std::string font){
+void Text::setFont(const std::string &font){
     TextComponent& textcomp = getComponent<TextComponent>();
 
     if (textcomp.font != font){

--- a/engine/core/object/ui/Text.h
+++ b/engine/core/object/ui/Text.h
@@ -30,10 +30,10 @@ namespace Supernova{
         void setMaxTextSize(unsigned int maxTextSize);
         unsigned int getMaxTextSize() const;
 
-        void setText(std::string text);
+        void setText(const std::string& text);
         std::string getText() const;
 
-        void setFont(std::string font);
+        void setFont(const std::string& font);
         std::string getFont() const;
 
         void setFontSize(unsigned int fontSize);


### PR DESCRIPTION
These changes aim to avoid generating two copies of the std::string when the classes' clients use the methods like setText:

```cpp
// This way the function will receive the parameter by copy
void setFont(std::string font);
```

```cpp
// Receives the string by reference without creating a new copy
void setFont(const std::string &font);
```

Let me know your thoughts, and I can replicate the same change throughout the project.
