### PR TITLE
Fix generated C++ string escaping

### DIFF
--- a/editor/Factory.cpp
+++ b/editor/Factory.cpp
@@ -428,7 +428,54 @@ std::string editor::Factory::formatUInt(unsigned int value) {
 }
 
 std::string editor::Factory::formatString(const std::string& value) {
-    return "\"" + value + "\"";
+    std::string result;
+    result.reserve(value.size() + 2);
+    result.push_back('"');
+
+    for (unsigned char c : value) {
+        switch (c) {
+            case '\\':
+                result += "\\\\";
+                break;
+            case '"':
+                result += "\\\"";
+                break;
+            case '\n':
+                result += "\\n";
+                break;
+            case '\r':
+                result += "\\r";
+                break;
+            case '\t':
+                result += "\\t";
+                break;
+            case '\b':
+                result += "\\b";
+                break;
+            case '\f':
+                result += "\\f";
+                break;
+            case '\v':
+                result += "\\v";
+                break;
+            case '\a':
+                result += "\\a";
+                break;
+            default:
+                if (c < 0x20 || c == 0x7F) {
+                    result.push_back('\\');
+                    result.push_back(static_cast<char>('0' + ((c >> 6) & 0x07)));
+                    result.push_back(static_cast<char>('0' + ((c >> 3) & 0x07)));
+                    result.push_back(static_cast<char>('0' + (c & 0x07)));
+                } else {
+                    result.push_back(static_cast<char>(c));
+                }
+                break;
+        }
+    }
+
+    result.push_back('"');
+    return result;
 }
 
 std::string editor::Factory::formatAttributeType(AttributeType type) {


### PR DESCRIPTION
Fixes #60 

This PR fixes invalid generated C++ code when exported scenes contain multiline strings.

Previously, `Factory::formatString` wrapped string values in quotes without escaping special characters. If a `Text` or `Label` value contained a newline, the generated `.cpp` file received a raw line break inside the string literal, which made the desktop build fail.

The fix updates `Factory::formatString` to generate valid C++ string literals by escaping:
- backslashes;
- double quotes;
- newlines;
- carriage returns;
- tabs;
- other control characters.

Example output:

  ```cpp
  text.text = "MainMenu\nMainMenu";

Assisted by ChatGPT.