### PR TITLE
fix: escape strings in generated C++

### DIFF
--- a/editor/Factory.cpp
+++ b/editor/Factory.cpp
@@ -428,7 +428,36 @@ std::string editor::Factory::formatUInt(unsigned int value) {
 }
 
 std::string editor::Factory::formatString(const std::string& value) {
-    return "\"" + value + "\"";
+    std::string escaped;
+    escaped.reserve(value.size() + 2);
+    escaped.push_back('"');
+
+    for (unsigned char character : value) {
+        switch (character) {
+            case '\\': escaped += "\\\\"; break;
+            case '"': escaped += "\\\""; break;
+            case '\n': escaped += "\\n"; break;
+            case '\r': escaped += "\\r"; break;
+            case '\t': escaped += "\\t"; break;
+            case '\b': escaped += "\\b"; break;
+            case '\f': escaped += "\\f"; break;
+            case '\v': escaped += "\\v"; break;
+            case '\a': escaped += "\\a"; break;
+            default:
+                if (character < 0x20 || character == 0x7f) {
+                    escaped += '\\\\';
+                    escaped.push_back(static_cast<char>('0' + ((character >> 6) & 0x07)));
+                    escaped.push_back(static_cast<char>('0' + ((character >> 3) & 0x07)));
+                    escaped.push_back(static_cast<char>('0' + (character & 0x07)));
+                } else {
+                    escaped.push_back(static_cast<char>(character));
+                }
+                break;
+        }
+    }
+
+    escaped.push_back('"');
+    return escaped;
 }
 
 std::string editor::Factory::formatAttributeType(AttributeType type) {


### PR DESCRIPTION
Fixes #60.

When a Text or Label value contained a newline, Factory::formatString copied it directly into the generated C++ source. The resulting raw newline terminated the string literal and made desktop exports fail to compile. Quotes, backslashes, and control characters could also produce invalid generated source.

This updates the shared formatter to emit valid C++ string escapes while preserving ordinary UTF-8 text. That covers Text/Label content and the other generated string properties using the same formatter.

Validation:
- Focused C++ smoke test passed for multiline text, quotes, backslashes, control characters, and UTF-8.
- git diff --check passed.
- Full local CMake configure/build could not start because this environment is missing the required libcurl development headers/library (`find_package(CURL REQUIRED)`).