### PR TITLE
Fix project Lua module loading and cache clearing

### DIFF
--- a/editor/Project.cpp
+++ b/editor/Project.cpp
@@ -7554,6 +7554,10 @@ void editor::Project::runPlayStartup(const std::shared_ptr<PlaySession>& session
                         SceneManager::setScenePtr(entry.sourceSceneId, entry.runtime->scene);
                     }
                 }
+                if (!hasCppScripts) {
+                    LuaBinding::clearLoadedProjectModules();
+                }
+
                 for (const auto& entry : runtimeScenesToInitialize) {
                     if (!entry.runtime) continue;
                     if (hasCppScripts) {

--- a/engine/core/script/LuaBinding.cpp
+++ b/engine/core/script/LuaBinding.cpp
@@ -92,6 +92,7 @@ void LuaBinding::createLuaState(){
     LuaBinding::luastate = luaL_newstate();
 
     registerClasses(luastate);
+    configureProjectLuaLoader();
     registerHelpersFunctions(luastate);
 }
 
@@ -350,7 +351,7 @@ int LuaBinding::moduleLoader(lua_State *L) {
     std::string filepath;
     Data filedata;
     
-    filepath = "lua://" + std::string("lua") + System::instance().getDirSeparator() + filename + ".lua";
+    filepath = "lua://" + std::string("") + filename + ".lua";
     filedata.open(filepath.c_str());
     if (filedata.getMemPtr() != NULL) {
         
@@ -359,8 +360,8 @@ int LuaBinding::moduleLoader(lua_State *L) {
         
         return 1;
     }
-    
-    filepath = "lua://" + std::string("") + filename + ".lua";
+
+    filepath = "lua://" + std::string("lua") + System::instance().getDirSeparator() + filename + ".lua";
     filedata.open(filepath.c_str());
     if (filedata.getMemPtr() != NULL) {
         
@@ -373,6 +374,14 @@ int LuaBinding::moduleLoader(lua_State *L) {
     lua_pushstring(L, "\n\tno file in assets directory");
     
     return 1;
+}
+
+void LuaBinding::configureProjectLuaLoader(){
+    std::string luadir = std::string("lua") + System::instance().getDirSeparator();
+
+    setLuaPath("lua://?.lua");
+    setLuaPath(std::string("lua://" + luadir + "?.lua").c_str());
+    setLuaSearcher(moduleLoader, true);
 }
 
 //The same msghandler of lua.c
@@ -399,8 +408,7 @@ void LuaBinding::init(){
 
     std::string luadir = std::string("lua") + System::instance().getDirSeparator();
 
-    setLuaPath(std::string("lua://" + luadir + "?.lua").c_str());
-    setLuaSearcher(moduleLoader, true);
+    configureProjectLuaLoader();
 
     std::string luafile = std::string("lua://") + "main.lua";
     std::string luafile_subdir = std::string("lua://") + luadir + "main.lua";
@@ -575,6 +583,54 @@ bool LuaBinding::pushEntityHandleByType(lua_State* L, doriax::Scene* scene, dori
         Log::warn("pushEntityHandleByType: unknown type '%s', falling back to EntityHandle", ptrTypeName.c_str());
     }
     return pushEntityHandleTyped<EntityHandle>(L, scene, entity);
+}
+
+void LuaBinding::clearLoadedProjectModules() {
+    lua_State* L = luastate;
+    if (!L) return;
+
+    lua_getglobal(L, "package");
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        return;
+    }
+
+    lua_getfield(L, -1, "loaded");
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 2);
+        return;
+    }
+
+    std::vector<std::string> modulesToClear;
+
+    lua_pushnil(L);
+    while (lua_next(L, -2) != 0) {
+        if (lua_isstring(L, -2)) {
+            std::string moduleName = lua_tostring(L, -2);
+            std::string filename = moduleName;
+            std::replace(filename.begin(), filename.end(), '.', System::instance().getDirSeparator());
+
+            Data filedata;
+            std::string filepath = "lua://" + filename + ".lua";
+            if (filedata.open(filepath.c_str()) == FileErrors::FILEDATA_OK) {
+                modulesToClear.push_back(moduleName);
+            } else {
+                filepath = "lua://" + std::string("lua") + System::instance().getDirSeparator() + filename + ".lua";
+                if (filedata.open(filepath.c_str()) == FileErrors::FILEDATA_OK) {
+                    modulesToClear.push_back(moduleName);
+                }
+            }
+        }
+        lua_pop(L, 1);
+    }
+
+    for (const std::string& moduleName : modulesToClear) {
+        lua_pushnil(L);
+        lua_setfield(L, -2, moduleName.c_str());
+        Log::debug("Cleared Lua project module cache: %s", moduleName.c_str());
+    }
+
+    lua_pop(L, 2);
 }
 
 void LuaBinding::initializeLuaScripts(Scene* scene) {

--- a/engine/core/script/LuaBinding.h
+++ b/engine/core/script/LuaBinding.h
@@ -25,6 +25,7 @@ namespace doriax {
         static void createLuaState();
         static int setLuaPath(const char* path);
         static int setLuaSearcher(lua_CFunction f, bool cleanSearchers = false);
+        static void configureProjectLuaLoader();
 
         static int luaRegisterEvent(lua_State* L);
         static int luaRegisterEngineEvent(lua_State* L);
@@ -76,6 +77,7 @@ namespace doriax {
         // For editor scripts use
         static void initializeLuaScripts(Scene* scene);
         static void cleanupLuaScripts(Scene* scene);
+        static void clearLoadedProjectModules();
 
         static std::string getLuaStackErrorString(lua_State* L, int index = -1);
         


### PR DESCRIPTION
Fixed #67 

Fixes Lua project module reloading during editor play.

The main issue was that project Lua modules loaded with `require` could remain cached in `package.loaded` between editor play runs. This meant changes to helper modules were not picked up unless the project manually cleared the module cache:

  ```lua
  local function reloadModule(name)
      package.loaded[name] = nil
      return require(name)
  end
  ```
This PR clears cached project Lua modules before starting a Lua-only play session from the editor.
It also adjusts Lua module loading slightly so the Lua searcher is configured when the shared Lua state is created. This lets require("module_name") resolve modules relative to the configured project Lua directory.

If a project uses:

  luaDir: scripts

then:
  ```lua
  require("game_state")
  ```
resolves against:

  <project>/scripts/game_state.lua

The existing lua/ lookup is kept as a compatibility fallback.

Summary:

- clear cached project Lua modules before editor Lua play starts;
- configure the project Lua module loader when the Lua state is created;
- resolve modules from the configured Lua directory through lua://?.lua;
- keep the previous lua/ fallback for compatibility;
- avoid changing the project script directory model.