### PR TITLE
fix: protect Lua event registration calls

### DIFF
--- a/engine/core/script/LuaBinding.cpp
+++ b/engine/core/script/LuaBinding.cpp
@@ -264,7 +264,9 @@ int LuaBinding::luaRegisterEventImpl(lua_State* L, int eventIndex, int selfIndex
     lua_pushstring(L, tag);
     lua_pushvalue(L, closureIndex);
 
-    lua_call(L, 3, 0);
+    if (pcallWithTraceback(L, 3, 0) != LUA_OK) {
+        return lua_error(L);
+    }
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- route the Lua `event:add` call through the existing traceback-aware protected call helper
- propagate registration errors to the calling Lua script instead of allowing an unprotected panic

## Validation
- source check: no raw `lua_call` remains in `LuaBinding.cpp`
- `git diff --check` — passed
- CMake configure was attempted but this environment lacks the system CURL development library (`CURL_LIBRARY`/`CURL_INCLUDE_DIR`)
