### PR TITLE
fix: clear Lua state after init errors

### DIFF
--- a/engine/core/script/LuaBinding.cpp
+++ b/engine/core/script/LuaBinding.cpp
@@ -418,12 +418,12 @@ void LuaBinding::init(){
         if(pcallWithTraceback(L, 0, LUA_MULTRET) != 0){
             Log::error("Lua Error: %s", getLuaStackErrorString(L, -1).c_str());
             lua_pop(L, 1);
-            lua_close(L);
+            cleanup();
         }
     }else{
         Log::error("Lua Error: %s", getLuaStackErrorString(L, -1).c_str());
         lua_pop(L, 1);
-        lua_close(L);
+        cleanup();
     }
 
 }


### PR DESCRIPTION
## Summary
- route Lua entrypoint load and execution failures through `LuaBinding::cleanup()`
- ensure the static Lua state pointer is cleared after the state is closed

## Validation
- exactly one direct `lua_close` remains, inside `cleanup()`
- `git diff --check` — passed
